### PR TITLE
Fix namespace capitalization

### DIFF
--- a/src/SimpleXmlReader/PathIterator.php
+++ b/src/SimpleXmlReader/PathIterator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleXMLReader;
+namespace SimpleXmlReader;
 
 use XMLReader;
 use Exception;


### PR DESCRIPTION
The PSR namespace is supposed to be `SimpleXmlReader` instead of `SimpleXMLReader`.
